### PR TITLE
change parentheses to brackets in genome names

### DIFF
--- a/conf/igenomes.config
+++ b/conf/igenomes.config
@@ -10,7 +10,7 @@
  params {
   // illumina iGenomes reference file paths on UPPMAX
   genomes {
-    'Homo_sapiens(GRCh38)' {
+    'Homo_sapiens[GRCh38]' {
       ncRNA_fa_bowtie = "s3://aladdin-genomes/Homo_sapiens/Ensembl/GRCh38/Annotation/SmallRNA/RNAtypes/bowtieindex.gtrnadb.mitotrna.mirbase.lnc.sno.sca.sn.misc.rRNA.rpmsk8_18_2022/"
       ncRNA_fa = "s3://aladdin-genomes/Homo_sapiens/Ensembl/GRCh38/Annotation/SmallRNA/RNAtypes/Homo_sapiens.GRCh38.105.gtrnadb.mitotrna.mirbase.lnc.sno.sca.sn.misc.rRNA.rpmsk8_18_2022_idx.fa"
       tx2gene = "s3://aladdin-genomes/Homo_sapiens/Ensembl/GRCh38/Annotation/SmallRNA/RNAtypes/smrnaseq_tx2genetable_withgenenames_9_15_2022.tsv"
@@ -19,7 +19,7 @@
       mirna_gtf = "s3://aladdin-genomes/Homo_sapiens/Ensembl/GRCh38/Annotation/SmallRNA/hsa.gff3"
       mirtrace_species = "hsa"
     }
-    'Rattus_norvegicus(Rnor_6.0)' {
+    'Rattus_norvegicus[Rnor_6.0]' {
       ncRNA_fa_bowtie = "s3://aladdin-genomes/Rattus_norvegicus/Ensembl/Rnor_6.0/Annotation/SmallRNA/RNAtypes/Rattus_norvegicus_Rnor6_104_smallRNAtypes_ref10_14_2022/"
       ncRNA_fa = "s3://aladdin-genomes/Rattus_norvegicus/Ensembl/Rnor_6.0/Annotation/SmallRNA/RNAtypes/Rattus_norvegicus.Rnor6.0_104.gtrnadb.mitotrna.mirbase.lnc.sno.sca.sn.misc.rRNA.rpmsk10_13_2022_idx.fa"
       tx2gene = "s3://aladdin-genomes/Rattus_norvegicus/Ensembl/Rnor_6.0/Annotation/SmallRNA/RNAtypes/smrnaseq_Rnor6.0_104_tx2genetable_withgenenames10_13_2022.tsv"
@@ -28,7 +28,7 @@
       mirna_gtf = "s3://aladdin-genomes/Rattus_norvegicus/Ensembl/Rnor_6.0/Annotation/SmallRNA/rno.gff3"
       mirtrace_species = "rno"
     }
-    'Mus_musculus(GRCm38)' {
+    'Mus_musculus[GRCm38]' {
       ncRNA_fa_bowtie = "s3://aladdin-genomes/Mus_musculus/Ensembl/GRCm38/Annotation/SmallRNA/RNAtypes/bowtieindex.gtrnadb.mitotrna.mirbase.lnc.sno.sca.sn.misc.rRNA.rpmsk11_3_2022/Mus_musculus_smallRNAtypes_ref11_3_2022_idx"
       ncRNA_fa = "s3://aladdin-genomes/Mus_musculus/Ensembl/GRCm38/Annotation/SmallRNA/RNAtypes/Mus_musculus.GRCm38.102.gtrnadb.mitotrna.mirbase.lnc.sno.sca.sn.misc.rRNA.rpmsk11_1_2022_idx.fa"
       tx2gene = "s3://aladdin-genomes/Mus_musculus/Ensembl/GRCm38/Annotation/SmallRNA/RNAtypes/smrnaseq_GRCm38_102_tx2genetable_withgenenames11_2_2022.tsv"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -32,7 +32,7 @@
                 "genome": {
                     "type": "string",
                     "description": "Reference genome used to align reads. Please contact us to add more species.",
-		            "enum": ["Homo_sapiens(GRCh38)", "Rattus_norvegicus(Rnor_6.0)", "Mus_musculus(GRCm38)"]
+		            "enum": ["Homo_sapiens[GRCh38]", "Rattus_norvegicus[Rnor_6.0]", "Mus_musculus[GRCm38]"]
                 },
 		        "save_reference": {
 		            "type": "boolean",


### PR DESCRIPTION
Parentheses cause a breakage in when Batch submits the job to docker via `bash -c`. Switch to brackets to avoid that. 