### PR TITLE
Update mirbase and ensembl links

### DIFF
--- a/assets/multiqc_plugins/multiqc_aladdin_smrnaseq/modules/deseq2_rnatypes/deseq2_rnatypes.py
+++ b/assets/multiqc_plugins/multiqc_aladdin_smrnaseq/modules/deseq2_rnatypes/deseq2_rnatypes.py
@@ -39,7 +39,7 @@ class MultiqcModule(BaseMultiqcModule):
         # Get the pvalue cutoff from config
         alpha = getattr(config, "isomiRs_alpha", 0.05)
         link_prefix = getattr(config, "ensembl_link_prefix", None)
-        if link_prefix is not None and re.search("ENS[a-zA-Z]*G00000", index):
+        if link_prefix is not None:
             link_prefix = '<a href=\"https://{}'.format(link_prefix)
         # Initialize the data dict
         self.deseq_results = dict()
@@ -285,7 +285,7 @@ class MultiqcModule(BaseMultiqcModule):
                 # Add link to the gene names
                 linklist = []
                 for index in genes.index:
-                    if link_prefix is not None:
+                    if link_prefix is not None and re.search("ENS[a-zA-Z]*G00000", index):
                         gene_link = link_prefix+index+'" target="_blank">'+index+"</a>"
                     else:
                         gene_link = index

--- a/assets/multiqc_plugins/multiqc_aladdin_smrnaseq/modules/deseq2_rnatypes/deseq2_rnatypes.py
+++ b/assets/multiqc_plugins/multiqc_aladdin_smrnaseq/modules/deseq2_rnatypes/deseq2_rnatypes.py
@@ -285,8 +285,7 @@ class MultiqcModule(BaseMultiqcModule):
                 # Add link to the gene names
                 linklist = []
                 for index in genes.index:
-                    #Use database-specific patterns to assign url from database
-                    if (link_prefix is not None) and (re.search("ENS[a-zA-Z]+G00000", index) or re.search("ENSG00000", index)):
+                    if link_prefix is not None:
                         gene_link = link_prefix+index+'" target="_blank">'+index+"</a>"
                     else:
                         gene_link = index

--- a/assets/multiqc_plugins/multiqc_aladdin_smrnaseq/modules/deseq2_rnatypes/deseq2_rnatypes.py
+++ b/assets/multiqc_plugins/multiqc_aladdin_smrnaseq/modules/deseq2_rnatypes/deseq2_rnatypes.py
@@ -39,7 +39,7 @@ class MultiqcModule(BaseMultiqcModule):
         # Get the pvalue cutoff from config
         alpha = getattr(config, "isomiRs_alpha", 0.05)
         link_prefix = getattr(config, "ensembl_link_prefix", None)
-        if link_prefix is not None:
+        if link_prefix is not None and re.search("ENS[a-zA-Z]*G00000", index):
             link_prefix = '<a href=\"https://{}'.format(link_prefix)
         # Initialize the data dict
         self.deseq_results = dict()

--- a/assets/multiqc_plugins/multiqc_aladdin_smrnaseq/modules/deseq2_rnatypes/deseq2_rnatypes.py
+++ b/assets/multiqc_plugins/multiqc_aladdin_smrnaseq/modules/deseq2_rnatypes/deseq2_rnatypes.py
@@ -286,7 +286,7 @@ class MultiqcModule(BaseMultiqcModule):
                 linklist = []
                 for index in genes.index:
                     #Use database-specific patterns to assign url from database
-                    if (link_prefix is not None) and re.search("ENSG00000", index):
+                    if (link_prefix is not None) and (re.search("ENS[a-zA-Z]+G00000", index) or re.search("ENSG00000", index))::
                         gene_link = link_prefix+index+'" target="_blank">'+index+"</a>"
                     else:
                         gene_link = index

--- a/assets/multiqc_plugins/multiqc_aladdin_smrnaseq/modules/deseq2_rnatypes/deseq2_rnatypes.py
+++ b/assets/multiqc_plugins/multiqc_aladdin_smrnaseq/modules/deseq2_rnatypes/deseq2_rnatypes.py
@@ -286,7 +286,7 @@ class MultiqcModule(BaseMultiqcModule):
                 linklist = []
                 for index in genes.index:
                     #Use database-specific patterns to assign url from database
-                    if (link_prefix is not None) and (re.search("ENS[a-zA-Z]+G00000", index) or re.search("ENSG00000", index))::
+                    if (link_prefix is not None) and (re.search("ENS[a-zA-Z]+G00000", index) or re.search("ENSG00000", index)):
                         gene_link = link_prefix+index+'" target="_blank">'+index+"</a>"
                     else:
                         gene_link = index

--- a/assets/multiqc_plugins/multiqc_aladdin_smrnaseq/modules/deseq2_rnatypes/deseq2_rnatypes.py
+++ b/assets/multiqc_plugins/multiqc_aladdin_smrnaseq/modules/deseq2_rnatypes/deseq2_rnatypes.py
@@ -38,6 +38,9 @@ class MultiqcModule(BaseMultiqcModule):
 
         # Get the pvalue cutoff from config
         alpha = getattr(config, "isomiRs_alpha", 0.05)
+        link_prefix = getattr(config, "ensembl_link_prefix", None)
+        if link_prefix is not None:
+            link_prefix = '<a href=\"https://{}'.format(link_prefix)
         # Initialize the data dict
         self.deseq_results = dict()
         # Find the data files
@@ -283,12 +286,11 @@ class MultiqcModule(BaseMultiqcModule):
                 linklist = []
                 for index in genes.index:
                     #Use database-specific patterns to assign url from database
-                    if re.search("ENSG00000", index):
-                        link_prefix = '<a href=https://uswest.ensembl.org/Homo_sapiens/Gene/Summary?db=core;g='+index+ \
-                        '>'+index+"</a>"
+                    if (link_prefix is not None) and re.search("ENSG00000", index):
+                        gene_link = link_prefix+index+'" target="_blank">'+index+"</a>"
                     else:
-                        link_prefix = index
-                    linklist.append(link_prefix)
+                        gene_link = index
+                    linklist.append(gene_link)
                 genes["gene_link"] = linklist
                 genes = genes[["gene_link", "gene_name", "baseMean", "log2FoldChange", "padj"]]
                 genes = genes.to_dict("records")

--- a/assets/multiqc_plugins/multiqc_aladdin_smrnaseq/modules/isomiRs/isomiRs.py
+++ b/assets/multiqc_plugins/multiqc_aladdin_smrnaseq/modules/isomiRs/isomiRs.py
@@ -37,7 +37,9 @@ class MultiqcModule(BaseMultiqcModule):
 
         # Get the pvalue cutoff from config
         alpha = getattr(config, "isomiRs_alpha", 0.05)
-        link_prefix = getattr(config, "gene_link_prefix", '<a href=\"http://www.mirbase.org/cgi-bin/mirna_entry.pl?acc=')
+        link_prefix = getattr(config, "mirbase_link_prefix", None)
+        if link_prefix is not None:
+            link_prefix = '<a href=\"https://{}'.format(link_prefix)
 
         # Initialize the data dict
         self.isomirs_results = dict()

--- a/conf/igenomes.config
+++ b/conf/igenomes.config
@@ -18,7 +18,7 @@
       idmaptoRNAtype = "s3://aladdin-genomes/Homo_sapiens/Ensembl/GRCh38/Annotation/SmallRNA/RNAtypes/idmaptornatypes.gtrnadb.mitorna.mirbase.ensembl.rRNArpmsk8_5_2022.txt"
       mirna_gtf = "s3://aladdin-genomes/Homo_sapiens/Ensembl/GRCh38/Annotation/SmallRNA/hsa.gff3"
       mirtrace_species = "hsa"
-      ensembl_web = "ensembl.org/Homo_sapiens/Gene/Summary?db=core;g="
+      ensembl_web = "https://useast.ensembl.org/Homo_sapiens/Gene/Summary?db=core;g="
       mirbase_web = "mirbase.org/results/?query="
     }
     'Rattus_norvegicus[Rnor_6.0]' {
@@ -29,6 +29,8 @@
       idmaptoRNAtype = "s3://aladdin-genomes/Rattus_norvegicus/Ensembl/Rnor_6.0/Annotation/SmallRNA/RNAtypes/idmaptornatypes.Ratticus_norvegicus_6.0_104_gtrnadbmitotrnadb.mirbase.lnc.sno.sca.sn.misc.rRNA.rpmsk10_13_2022.txt"
       mirna_gtf = "s3://aladdin-genomes/Rattus_norvegicus/Ensembl/Rnor_6.0/Annotation/SmallRNA/rno.gff3"
       mirtrace_species = "rno"
+      ensembl_web = "https://may2021.archive.ensembl.org/Rattus_norvegicus/Gene/Summary?db=core;g="
+      mirbase_web = "mirbase.org/results/?query="
     }
     'Mus_musculus[GRCm38]' {
       ncRNA_fa_bowtie = "s3://aladdin-genomes/Mus_musculus/Ensembl/GRCm38/Annotation/SmallRNA/RNAtypes/bowtieindex.gtrnadb.mitotrna.mirbase.lnc.sno.sca.sn.misc.rRNA.rpmsk11_3_2022/Mus_musculus_smallRNAtypes_ref11_3_2022_idx"
@@ -38,6 +40,8 @@
       idmaptoRNAtype = "s3://aladdin-genomes/Mus_musculus/Ensembl/GRCm38/Annotation/SmallRNA/RNAtypes/idmaptornatypes.Mus_musculus_GRCm38_102_gtrnadbmitotrnadb.mirbase.lnc.sno.sca.sn.misc.rRNA.rpmsk11_1_2022.txt"
       mirna_gtf = "s3://aladdin-genomes/Mus_musculus/Ensembl/GRCm38/Annotation/SmallRNA/mmu.gff3"
       mirtrace_species = "mmu"
+      ensembl_web = "https://nov2020.archive.ensembl.org/Mus_musculus/Gene/Summary?db=core;g="
+      mirbase_web = "mirbase.org/results/?query="
     }
   }
 }

--- a/conf/igenomes.config
+++ b/conf/igenomes.config
@@ -18,7 +18,7 @@
       idmaptoRNAtype = "s3://aladdin-genomes/Homo_sapiens/Ensembl/GRCh38/Annotation/SmallRNA/RNAtypes/idmaptornatypes.gtrnadb.mitorna.mirbase.ensembl.rRNArpmsk8_5_2022.txt"
       mirna_gtf = "s3://aladdin-genomes/Homo_sapiens/Ensembl/GRCh38/Annotation/SmallRNA/hsa.gff3"
       mirtrace_species = "hsa"
-      ensembl_web = "https://useast.ensembl.org/Homo_sapiens/Gene/Summary?db=core;g="
+      ensembl_web = "ensembl.org/Homo_sapiens/Gene/Summary?db=core;g="
       mirbase_web = "mirbase.org/results/?query="
     }
     'Rattus_norvegicus[Rnor_6.0]' {
@@ -29,7 +29,7 @@
       idmaptoRNAtype = "s3://aladdin-genomes/Rattus_norvegicus/Ensembl/Rnor_6.0/Annotation/SmallRNA/RNAtypes/idmaptornatypes.Ratticus_norvegicus_6.0_104_gtrnadbmitotrnadb.mirbase.lnc.sno.sca.sn.misc.rRNA.rpmsk10_13_2022.txt"
       mirna_gtf = "s3://aladdin-genomes/Rattus_norvegicus/Ensembl/Rnor_6.0/Annotation/SmallRNA/rno.gff3"
       mirtrace_species = "rno"
-      ensembl_web = "https://may2021.archive.ensembl.org/Rattus_norvegicus/Gene/Summary?db=core;g="
+      ensembl_web = "may2021.archive.ensembl.org/Rattus_norvegicus/Gene/Summary?db=core;g="
       mirbase_web = "mirbase.org/results/?query="
     }
     'Mus_musculus[GRCm38]' {
@@ -40,7 +40,7 @@
       idmaptoRNAtype = "s3://aladdin-genomes/Mus_musculus/Ensembl/GRCm38/Annotation/SmallRNA/RNAtypes/idmaptornatypes.Mus_musculus_GRCm38_102_gtrnadbmitotrnadb.mirbase.lnc.sno.sca.sn.misc.rRNA.rpmsk11_1_2022.txt"
       mirna_gtf = "s3://aladdin-genomes/Mus_musculus/Ensembl/GRCm38/Annotation/SmallRNA/mmu.gff3"
       mirtrace_species = "mmu"
-      ensembl_web = "https://nov2020.archive.ensembl.org/Mus_musculus/Gene/Summary?db=core;g="
+      ensembl_web = "nov2020.archive.ensembl.org/Mus_musculus/Gene/Summary?db=core;g="
       mirbase_web = "mirbase.org/results/?query="
     }
   }

--- a/conf/igenomes.config
+++ b/conf/igenomes.config
@@ -18,7 +18,7 @@
       idmaptoRNAtype = "s3://aladdin-genomes/Homo_sapiens/Ensembl/GRCh38/Annotation/SmallRNA/RNAtypes/idmaptornatypes.gtrnadb.mitorna.mirbase.ensembl.rRNArpmsk8_5_2022.txt"
       mirna_gtf = "s3://aladdin-genomes/Homo_sapiens/Ensembl/GRCh38/Annotation/SmallRNA/hsa.gff3"
       mirtrace_species = "hsa"
-      ensembl_web = "ensembl.org/Homo_sapiens/Gene/Summary?db=core;g="
+      ensembl_web = "www.ensembl.org/id/"
       mirbase_web = "mirbase.org/results/?query="
     }
     'Rattus_norvegicus[Rnor_6.0]' {
@@ -29,7 +29,7 @@
       idmaptoRNAtype = "s3://aladdin-genomes/Rattus_norvegicus/Ensembl/Rnor_6.0/Annotation/SmallRNA/RNAtypes/idmaptornatypes.Ratticus_norvegicus_6.0_104_gtrnadbmitotrnadb.mirbase.lnc.sno.sca.sn.misc.rRNA.rpmsk10_13_2022.txt"
       mirna_gtf = "s3://aladdin-genomes/Rattus_norvegicus/Ensembl/Rnor_6.0/Annotation/SmallRNA/rno.gff3"
       mirtrace_species = "rno"
-      ensembl_web = "may2021.archive.ensembl.org/Rattus_norvegicus/Gene/Summary?db=core;g="
+      ensembl_web = "www.ensembl.org/id/"
       mirbase_web = "mirbase.org/results/?query="
     }
     'Mus_musculus[GRCm38]' {
@@ -40,7 +40,7 @@
       idmaptoRNAtype = "s3://aladdin-genomes/Mus_musculus/Ensembl/GRCm38/Annotation/SmallRNA/RNAtypes/idmaptornatypes.Mus_musculus_GRCm38_102_gtrnadbmitotrnadb.mirbase.lnc.sno.sca.sn.misc.rRNA.rpmsk11_1_2022.txt"
       mirna_gtf = "s3://aladdin-genomes/Mus_musculus/Ensembl/GRCm38/Annotation/SmallRNA/mmu.gff3"
       mirtrace_species = "mmu"
-      ensembl_web = "nov2020.archive.ensembl.org/Mus_musculus/Gene/Summary?db=core;g="
+      ensembl_web = "www.ensembl.org/id/"
       mirbase_web = "mirbase.org/results/?query="
     }
   }

--- a/conf/igenomes.config
+++ b/conf/igenomes.config
@@ -18,6 +18,8 @@
       idmaptoRNAtype = "s3://aladdin-genomes/Homo_sapiens/Ensembl/GRCh38/Annotation/SmallRNA/RNAtypes/idmaptornatypes.gtrnadb.mitorna.mirbase.ensembl.rRNArpmsk8_5_2022.txt"
       mirna_gtf = "s3://aladdin-genomes/Homo_sapiens/Ensembl/GRCh38/Annotation/SmallRNA/hsa.gff3"
       mirtrace_species = "hsa"
+      ensembl_web = "ensembl.org/Homo_sapiens/Gene/Summary?db=core;g="
+      mirbase_web = "mirbase.org/results/?query="
     }
     'Rattus_norvegicus[Rnor_6.0]' {
       ncRNA_fa_bowtie = "s3://aladdin-genomes/Rattus_norvegicus/Ensembl/Rnor_6.0/Annotation/SmallRNA/RNAtypes/Rattus_norvegicus_Rnor6_104_smallRNAtypes_ref10_14_2022/"

--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,6 @@ dependencies:
   - samtools=1.16.1=h6899075_0
   - bowtie=1.3.1=py38h70e88c0_6
   - multiqc=1.9=py_1
-  - seaborn=0.13.0=hd8ed1ab_0
   - mirtop=0.4.23=pyh864c0ab_1
   - seqcluster=1.2.7=pyh864c0ab_1
   - fastx_toolkit=0.0.14=0
@@ -34,7 +33,6 @@ dependencies:
   - mirtrace=1.0.1=0
   - rsem=1.2.28=0
   - bioconductor-isomirs=1.18.1=r40hdfd78af_0
-  - graphviz=7.1.0=h2e5815a_0
   - bioconductor-genomeinfodbdata=1.2.4=r40hdfd78af_2 # Pin this to specific version so it works with isomiRs
   - bioconductor-tximport=1.18.0=r40hdfd78af_1
   - bioconductor-deseq2=1.30.1=r40h399db7b_0

--- a/environment.yml
+++ b/environment.yml
@@ -15,16 +15,17 @@ dependencies:
   - r-matrixstats=0.57.0=r40hcdcec82_0
   - r-dplyr=1.0.2=r40h0357c0b_0 # New dplyr version causes isomiRs bug, see bioconda-recipes issue #26558
   - r-ggplot2=3.3.2=r40h6115d3f_0
-  - pandas=1.2.2=py37hdc94413_0
-  - boto3=1.17.10=pyhd8ed1ab_0
+  - pandas=2.0.3=py38h01efb38_1
+  - boto3=1.34.97=pyhd8ed1ab_0
   - matplotlib=3.3.2=0
   - xorg-libxaw=1.0.14=h7f98852_1 # Needed for jpeg function in R
   ## bioconda packages
   - fastqc=0.11.9=0
   - trim-galore=0.6.6=0
   - samtools=1.16.1=h6899075_0
-  - bowtie=1.3.0=py37h9a982cc_1
+  - bowtie=1.3.1=py38h70e88c0_6
   - multiqc=1.9=py_1
+  - seaborn=0.13.0=hd8ed1ab_0
   - mirtop=0.4.23=pyh864c0ab_1
   - seqcluster=1.2.7=pyh864c0ab_1
   - fastx_toolkit=0.0.14=0
@@ -33,8 +34,9 @@ dependencies:
   - mirtrace=1.0.1=0
   - rsem=1.2.28=0
   - bioconductor-isomirs=1.18.1=r40hdfd78af_0
+  - graphviz=7.1.0=h2e5815a_0
   - bioconductor-genomeinfodbdata=1.2.4=r40hdfd78af_2 # Pin this to specific version so it works with isomiRs
   - bioconductor-tximport=1.18.0=r40hdfd78af_1
   - bioconductor-deseq2=1.30.1=r40h399db7b_0
   - bioawk=1.0=hed695b0_5
-  - rseqc=4.0.0=py37hf01694f_0
+  - rseqc=5.0.3=py38he5da3d1_1

--- a/main.nf
+++ b/main.nf
@@ -31,6 +31,8 @@ params.ncRNA_fa = params.genome ? params.genomes[params.genome].ncRNA_fa ?: fals
 params.ncRNA_fa_bowtie = params.genome ? params.genomes[ params.genome ].ncRNA_fa_bowtie ?: false : false
 params.idmaptoRNAtype = params.genome ? params.genomes[ params.genome ].idmaptoRNAtype ?: false : false
 params.tx2gene = params.genome ? params.genomes[ params.genome ].tx2gene ?: false : false
+params.ensembl_web = params.genomes[ params.genome ].ensembl_web ?: false
+params.mirbase_web = params.genomes[ params.genome ].mirbase_web ?: false
 params.mirtrace_species = params.genome ? params.genomes[ params.genome ].mirtrace_species ?: false : false
 if( !params.mirtrace_species && params.genome != "artificial" ) {
     exit 1, "Reference species for miRTrace is not defined."
@@ -170,6 +172,8 @@ include { multiqc } from "./processes/multiqc" addParams(
     publish_dir: "${outdir}/MultiQC",
     skip_multiqc: params.skip_multiqc,
     run_name : summary["Run Name"],
+    ensembl_web : params.ensembl_web,
+    mirbase_web : params.mirbase_web,
     isomirs_fdr: params.isomirs_fdr
 )
 include { summarize_downloads } from "./processes/summarize_downloads" addParams(

--- a/nextflow.config
+++ b/nextflow.config
@@ -49,7 +49,7 @@ params {
 
 // Container slug. Stable releases should specify release tag!
 // Developmental code should specify :dev
-process.container = 'nsharpzymo/aladdin-smrnaseq_temp:1.0.1'
+process.container = 'nsharpzymo/aladdin-smrnaseq_temp:1.0.2'
  
 // Load base.config by default for all pipelines
 includeConfig 'conf/base.config'

--- a/nextflow.config
+++ b/nextflow.config
@@ -49,7 +49,7 @@ params {
 
 // Container slug. Stable releases should specify release tag!
 // Developmental code should specify :dev
-process.container = 'zymoresearch/aladdin-smrnaseq:1.0.0'
+process.container = 'nsharpzymo/aladdin-smrnaseq_temp:1.0.1'
  
 // Load base.config by default for all pipelines
 includeConfig 'conf/base.config'

--- a/nextflow.config
+++ b/nextflow.config
@@ -49,7 +49,7 @@ params {
 
 // Container slug. Stable releases should specify release tag!
 // Developmental code should specify :dev
-process.container = 'zymoresearch/aladdin-smrnaseq:1.0.0'
+process.container = 'zymoresearch/aladdin-smrnaseq:1.0.1'
  
 // Load base.config by default for all pipelines
 includeConfig 'conf/base.config'

--- a/nextflow.config
+++ b/nextflow.config
@@ -49,7 +49,7 @@ params {
 
 // Container slug. Stable releases should specify release tag!
 // Developmental code should specify :dev
-process.container = 'nsharpzymo/aladdin-smrnaseq_temp:1.0.2'
+process.container = 'zymoresearch/aladdin-smrnaseq:1.0.0'
  
 // Load base.config by default for all pipelines
 includeConfig 'conf/base.config'

--- a/processes/multiqc.nf
+++ b/processes/multiqc.nf
@@ -13,7 +13,7 @@ process multiqc {
     !params.skip_multiqc
 
     input:
-    path multiqc_config
+    path ('original_multiqc_config.yaml')
     path ('fastqc/*')
     path ('trim_galore/*')
     path ('mirtrace/*')
@@ -32,16 +32,18 @@ process multiqc {
     script:
     rtitle = params.run_name ? "--title \"${params.run_name}\"" : ''
     rfilename = params.run_name ? "--filename " + params.run_name.replaceAll('\\W','_').replaceAll('_+','_') + "_multiqc_report" : ''
-    ensembl_link = params.ensembl_web ? "ensembl_link_prefix: $params.ensembl_web" : ''
-    mirbase_link = params.mirbase_web ? "mirbase_link_prefix: $params.mirbase_web" : ''
+    ensembl_link = params.ensembl_web ? "ensembl_link_prefix: ${params.ensembl_web}" : ''
+    mirbase_link = params.mirbase_web ? "mirbase_link_prefix: ${params.mirbase_web}" : ''
     """
     cat $summary_header $workflow_summary > workflow_summary_mqc.yaml
     echo '    </dl>' >> workflow_summary_mqc.yaml
     rm $summary_header $workflow_summary
-    echo '$ensembl_link' >> $multiqc_config
-    echo '$mirbase_link' >> $multiqc_config
-    echo 'isomiRs_alpha: ${params.isomirs_fdr}' >> $multiqc_config
-    multiqc . -f $rtitle $rfilename --config $multiqc_config -m mirtrace -m Trim_Galore \\
+    cat original_multiqc_config.yaml > multiqc_config.yaml
+    rm original_multiqc_config.yaml
+    echo '$ensembl_link' >> multiqc_config.yaml
+    echo '$mirbase_link' >> multiqc_config.yaml
+    echo 'isomiRs_alpha: ${params.isomirs_fdr}' >> multiqc_config.yaml
+    multiqc . -f $rtitle $rfilename --config multiqc_config.yaml -m mirtrace -m Trim_Galore \\
               -m fastqc -m custom_content -m isomiRs -m deseq2_rnatypes -m plot_sample_distance -m plot_gene_heatmap
     """
 }

--- a/processes/multiqc.nf
+++ b/processes/multiqc.nf
@@ -3,6 +3,8 @@ params.publish_dir = "MultiQC"
 params.skip_multiqc = false
 params.run_name = false
 params.isomirs_fdr = 0.05
+params.ensembl_link = false
+params.mirbase_link = false
 
 process multiqc {
     publishDir "${params.publish_dir}", mode: 'copy'
@@ -30,10 +32,14 @@ process multiqc {
     script:
     rtitle = params.run_name ? "--title \"${params.run_name}\"" : ''
     rfilename = params.run_name ? "--filename " + params.run_name.replaceAll('\\W','_').replaceAll('_+','_') + "_multiqc_report" : ''
+    ensembl_link = params.ensembl_web ? "ensembl_link_prefix: $params.ensembl_web" : ''
+    mirbase_link = params.mirbase_web ? "mirbase_link_prefix: $params.mirbase_web" : ''
     """
     cat $summary_header $workflow_summary > workflow_summary_mqc.yaml
     echo '    </dl>' >> workflow_summary_mqc.yaml
     rm $summary_header $workflow_summary
+    echo '$ensembl_link' >> $multiqc_config
+    echo '$mirbase_link' >> $multiqc_config
     echo 'isomiRs_alpha: ${params.isomirs_fdr}' >> $multiqc_config
     multiqc . -f $rtitle $rfilename --config $multiqc_config -m mirtrace -m Trim_Galore \\
               -m fastqc -m custom_content -m isomiRs -m deseq2_rnatypes -m plot_sample_distance -m plot_gene_heatmap


### PR DESCRIPTION
- mirbase and ensembl links updated for all genomes
- ensembl links now work with rat and mouse genomes (used to be only human) 